### PR TITLE
check for login duplicate

### DIFF
--- a/src/components/AdminAddUser.vue
+++ b/src/components/AdminAddUser.vue
@@ -37,7 +37,8 @@
                         <input v-model="baseLogin"
                           type="text" placeholder="login" name="login"
                           class="form-control" :class="{'is-invalid': errors.has('login') }"
-                          v-validate="`required|min:3|max:${20-String(qty).length}|iotlabLogin`">
+                          v-validate="`required|min:3|max:${20-String(qty).length}|iotlabLogin|checkDuplicate`"
+                          data-vv-delay="400">
                         <span class="input-group-addon" v-text="`1 to ${qty}`"></span>
                       </div>
                       <div class="invalid-feedback" v-show="errors.has('login')"
@@ -94,6 +95,17 @@ export default {
     Validator.extend('iotlabLogin', {
       getMessage: field => 'Must be a valid iotlab login (use only a-z & 0-9 characters).',
       validate: login => /^[a-z][a-z0-9]{3,19}$/.test(login + String(this.qty)),
+    })
+    Validator.extend('checkDuplicate', {
+      getMessage: field => 'This login already exists.',
+      validate: async login => {
+        try {
+          await iotlab.getUserInfo(login + '1')
+          return false
+        } catch (err) {
+          return true
+        }
+      },
     })
   },
 


### PR DESCRIPTION
Check if desired login already exists during multiple account creation.

Use a debounce delay of 400ms to limit API calls and make a better experience. 

Existence of only the first account of the series (with suffix 1) is checked, but this should cover most cases.