### PR TITLE
ExperimentDetails: add actions column in nodes table

### DIFF
--- a/src/views/ExperimentDetails.vue
+++ b/src/views/ExperimentDetails.vue
@@ -122,7 +122,7 @@
           </div>
           <div class="modal-body py-4">
             <label class="custom-file">
-              <input type="file" id="file" ref="firmwareFile" class="custom-file-input">
+              <input type="file" id="file" ref="firmwareFile" class="custom-file-input" @change="changeFirmwareFile('firmwareFile')">
               <span class="custom-file-control">{{firmwareFile && firmwareFile.name}}</span>
             </label>
           </div>
@@ -335,6 +335,10 @@ export default {
       }
     },
 
+    changeFirmwareFile (ref) {
+      this.firmwareFile = this.$refs[ref].files[0]
+    },
+
     flashFirmware (ref) {
       if (this.currentNode !== undefined) {
         this.flashFirmwareToCurrentNode(ref)
@@ -356,7 +360,6 @@ export default {
         return
       }
 
-      this.firmwareFile = this.$refs[ref].files[0]
       if (this.firmwareFile === undefined) return
 
       this.$notify({ text: 'Uploading file...', type: 'info', duration: -1 })


### PR DESCRIPTION
This PR adds a new "Actions" columns in the nodes table: this column gives the possibility to perform an action on a single node without having to select it, click the "Action on selected nodes button", click the desired action.

The logic behind actions is slightly adapted for single node action (using an attribute currentNode in the component data).

Finally, I removed the call to `flashFirmware` when the file is changed in the popup. When I was clicking on the "Flash" button of the popup, the firmware was flashed twice (easily reproducible on a slow network). Now the user has to click "Flash" to start the process, this is more obvious, but requires an extra click.