### PR TITLE
Terminal: accept all character from websockets

### DIFF
--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -141,10 +141,6 @@ export default {
           } else if (event.key === 'Del') {
             term.write('\b \b')
           } else {
-            /* Only accept ASCII characters */
-            if (key.charCodeAt(0) >= 127) {
-              return
-            }
             term.write(key)
             if (event.key === 'Enter') {
               term.write('\n')


### PR DESCRIPTION
Remove the limitation on ASCII characters. Requires https://github.com/iot-lab/iot-lab-websocket/pull/3 to be deployed on all site first.