### PR TITLE
polling bug: try fix by stopping polling when fetch experiments errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "testbed-webportal",
-  "version": "1.0.2",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.1.1",
   "name": "testbed-webportal",
   "author": "Benoit Formet",
   "private": true,

--- a/src/components/ExperimentList.vue
+++ b/src/components/ExperimentList.vue
@@ -247,6 +247,9 @@ export default {
         })).sort((exp1, exp2) => exp2.id - exp1.id) // order by reverse ID
       } catch (err) {
         this.$notify({text: 'Failed to fetch experiments', type: 'error'})
+        blured = true
+        this.$notify({text: 'Dashboard refresh stopped due to an error, do a manual refresh to retry', type: 'info', duration: -1, group: 'alt'})
+        this.stopPolling()
       }
 
       if (this.experiments.length < previous.length) {


### PR DESCRIPTION
I tested by deploying on dev, seems to be working (to raise artificially an error, do `iotlab.getAllExperiments = () => { throw new Error();}` in the console )