### PR TITLE
style: remove border when link gets focus (only Firefox)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -163,4 +163,7 @@ html {
   padding: 1.5em 2.5em;
   margin-top: 200px;
 }
+a:focus {
+  outline: none;
+}
 </style>


### PR DESCRIPTION
I browse the web with Firefox and links that gets focuses on the webportal always have a dotted border around them. This is not very nice.

This is adapting the main css to avoid this.

Tested on Firefox and Chrome and didn't notice any regression.