### PR TITLE
Remove the `inactive` item from groups list

### DIFF
--- a/src/views/AdminUsers.vue
+++ b/src/views/AdminUsers.vue
@@ -9,8 +9,7 @@
         </div>
       </div>
       <select class="form-control custom-select mr-2" v-model="showGroup" @change="showUsers">
-        <option value="" disabled>Show user group</option>
-        <option value="inactive">inactive users</option>
+        <option value="" disabled>Show users in group</option>
         <option v-for="group in store.groups" :value="group.name">{{group.name}}</option>
       </select>
       <i class="fa fa-lg fa-spinner fa-spin ml-1 mr-auto" :class="spinner ? 'text-dark' : 'text-white'"></i>
@@ -256,7 +255,7 @@ export default {
     async showUsers () {
       delete this.$route.query.search
       this.searchPattern = ''
-      const filter = this.showGroup === 'inactive' ? {status: 'inactive'} : {group: this.showGroup}
+      const filter = {group: this.showGroup}
       this.spinner = true
       this.users = await iotlab.getUsers(filter).catch(err => {
         this.$notify({ text: err.response.data.message || 'Failed to fetch users', type: 'error' })

--- a/tests/unit/__snapshots__/AdminUsers.spec.js.snap
+++ b/tests/unit/__snapshots__/AdminUsers.spec.js.snap
@@ -44,13 +44,7 @@ exports[`AdminUsers.vue should match snapshot 1`] = `
         disabled="disabled"
         value=""
       >
-        Show user group
-      </option>
-       
-      <option
-        value="inactive"
-      >
-        inactive users
+        Show users in group
       </option>
        
     </select>


### PR DESCRIPTION
Fist, because it is not a user group, but a user state.
Second, because, on production, it can cause a crash due to a too big ldap requestpagination. Waiting for pagination mecanism.