### PR TITLE
save user.login when logging in

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -17,7 +17,7 @@ export const auth = {
     await iotlab.getUserInfo()
       .then(user => {
         this.loggedIn = true
-        this.username = username
+        this.username = user.login
         this.isAdmin = user.groups.includes('admin')
         localStorage.setItem('loggedIn', this.loggedIn)
         localStorage.setItem('isAdmin', this.isAdmin)


### PR DESCRIPTION
fix for #84 

When logging in, we save in localstorage the `login` field that we fetch from the `GET /user` call, instead of the username value (which can be either login or email)