### PR TITLE
tests: /api/user for user webportal: login is webportal, not toto

### DIFF
--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -41,7 +41,7 @@ Cypress.Commands.add('login', (userType, options = {}) => {
   // auth.doLogin(user.login, user.password)
 
   cy.server()
-  cy.route('/api/user', {"firstName":"Webportal","lastName":"Webportal","email":"admin@iot-lab.info","organization":"Webportal","city":"Webportal","country":"France","login":"toto","motivations":"Webportal account with admin role access","status":"active","created":"2017-10-27T08:37:08Z","groups":["admin"],"sshkeys":["no need"]})
+  cy.route('/api/user', {"firstName":"Webportal","lastName":"Webportal","email":"admin@iot-lab.info","organization":"Webportal","city":"Webportal","country":"France","login":"webportal","motivations":"Webportal account with admin role access","status":"active","created":"2017-10-27T08:37:08Z","groups":["admin"],"sshkeys":["no need"]})
   cy.visit('/login')
   cy.get('input[placeholder=Username]').type(user.login)
   cy.get('input[placeholder=Password]').type(user.password + '{enter}').should(() => {


### PR DESCRIPTION
@aabadie that fix passes in CI https://ci.inria.fr/iot-lab/job/testbed-webportal-all/4/ :+1: just a mock json that used "toto" as login instead of "webportal"
