### PR TITLE
Fix login

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -9,10 +9,6 @@ export const auth = {
 
   async doLogin (username, password) {
     iotlab.create(username, password)
-    localStorage.setItem('apiAuth', JSON.stringify({
-      username: username,
-      password: password,
-    }))
 
     await iotlab.getUserInfo()
       .then(user => {
@@ -22,6 +18,10 @@ export const auth = {
         localStorage.setItem('loggedIn', this.loggedIn)
         localStorage.setItem('isAdmin', this.isAdmin)
         localStorage.setItem('username', this.username)
+        localStorage.setItem('apiAuth', JSON.stringify({
+          username: this.username,
+          password: password,
+        }))
       })
       .catch(err => {
       // console.log(err)


### PR DESCRIPTION
Apparently #85 was not sufficient to properly fix login & logout.

- on logging out, the 'username' field stored in localStorage wasn't cleaned up. Might not be problematic, might be.
- the 'apiAuth' field stored in localStorage, which is used for subsequent calls, when coming back to the page after a refresh, etc, had as a username the email of the user (in case the user tried to login with his email), which is problematic. The "login" endpoint works fine with the email, but others, not really. Therefore the 'apiAuth' storage should use as username the 'login' field that is fetched after a successful login.
    
